### PR TITLE
Add explicit UTF8 TextEncoding to Streams to fix filters with special characters

### DIFF
--- a/Source/Codeunits/Cod81001.DETDataEditorMgt.al
+++ b/Source/Codeunits/Cod81001.DETDataEditorMgt.al
@@ -1087,11 +1087,11 @@ codeunit 81001 "DET Data Editor Mgt."
         if not TempDataEditorBuffer.Get(0) then begin
             TempDataEditorBuffer.Init();
             TempDataEditorBuffer."Entry No." := 0;
-            TempDataEditorBuffer."Data To Process".CreateOutStream(OutStreamToProcess);
+            TempDataEditorBuffer."Data To Process".CreateOutStream(OutStreamToProcess, TextEncoding::UTF8);
             JObject.WriteTo(OutStreamToProcess);
             TempDataEditorBuffer.Insert();
         end else begin
-            TempDataEditorBuffer."Data To Process".CreateOutStream(OutStreamToProcess);
+            TempDataEditorBuffer."Data To Process".CreateOutStream(OutStreamToProcess, TextEncoding::UTF8);
             JObject.WriteTo(OutStreamToProcess);
             TempDataEditorBuffer.Modify();
         end;

--- a/Source/Codeunits/Cod81002.DETReadDataBatch.al
+++ b/Source/Codeunits/Cod81002.DETReadDataBatch.al
@@ -159,7 +159,7 @@ codeunit 81002 "DET Read Data Batch"
         ValueInStream: InStream;
         BufferTxt: Text;
     begin
-        TempBlob.CreateInStream(ValueInStream);
+        TempBlob.CreateInStream(ValueInStream, TextEncoding::UTF8);
         while not ValueInStream.EOS() do begin
             ValueInStream.Read(BufferTxt);
             Response += BufferTxt;


### PR DESCRIPTION
I noticed an issue yesterday where filters with a special character (`Ü` in a Code field in a German SaaS Environment to be specific) would cause the data editor to not find any records. Substituting the umlaut character with a `*` got the expected result.

Adding explicit UTF8 TextEncoding to CreateInstream and CreateOutstream fixes this issue on my sandbox system.
I don't think this change has any unwanted sideeffects. UTF16 might be better for some asian languages but UTF8 should still work for them.